### PR TITLE
feat: Customizable Dashboard

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -217,7 +217,15 @@ const fixLayout = (layout: any, modules: string[]) => {
     const missing = modules.filter(x => !layoutKeys.includes(x))
     missing.forEach(m => {
       const ref = defaultLayout.filter(x => x.i == m)[0]
-      fixed.push(ref)
+      fixed.push({
+        i: m,
+        x: 0,
+        y: Infinity,
+        w: ref.w,
+        h: ref.h,
+        minW: ref.minW,
+        minH: ref.minH
+      })
     })
   }
 

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -82,7 +82,7 @@ export function ModularDashboard({ eventCode, teamNumber, ranking, rankings, tea
         cols={{ xxs: 1, sm: 12 }}
         rowHeight={30}
         isBounded={true}
-        containerPadding={[0, 0]}
+        containerPadding={[0, 0]} // must be zero to prevent a bug
         onLayoutChange={saveLayout}
       >
         {modules.includes("Performance") && (<div key="Performance">
@@ -120,15 +120,15 @@ export function ModularDashboard({ eventCode, teamNumber, ranking, rankings, tea
 }
 
 const defaultLayout = [
-  { i: "Performance", x: 4, y: 0, w: 4, h: 8 },
-  { i: "Rankings", x: 0, y: 0, w: 4, h: 24 },
-  { i: "OPR", x: 4, y: 6, w: 8, h: 8 },
-  { i: "Alliance", x: 8, y: 6, w: 4, h: 8 },
-  { i: "OPR (Small)", x: 4, y: 12, w: 4, h: 8 },
-  { i: "Event Overview", x: 8, y: 0, w: 4, h: 8 },
-  { i: "Rank Percentile", x: 0, y: 12, w: 4, h: 5 },
-  { i: "Win Rate", x: 4, y: 12, w: 4, h: 5 },
-  { i: "Average Score", x: 8, y: 12, w: 4, h: 5 }
+  { i: "Performance", x: 4, y: 0, w: 4, h: 8, minW: 2, minH: 6 },
+  { i: "Rankings", x: 0, y: 0, w: 4, h: 24, minW: 2, minH: 4 },
+  { i: "OPR", x: 4, y: 6, w: 8, h: 8, minW: 6, minH: 8 },
+  { i: "Alliance", x: 8, y: 6, w: 4, h: 8, minW: 2, minH: 6 },
+  { i: "OPR (Small)", x: 4, y: 12, w: 4, h: 8, minW: 4, minH: 7 },
+  { i: "Event Overview", x: 8, y: 0, w: 4, h: 8, minW: 3, minH: 6 },
+  { i: "Rank Percentile", x: 0, y: 12, w: 4, h: 5, minW: 3, minH: 4 },
+  { i: "Win Rate", x: 4, y: 12, w: 4, h: 5, minW: 3, minH: 4 },
+  { i: "Average Score", x: 8, y: 12, w: 4, h: 5, minW: 3, minH: 4 }
 ]
 
 const defaultModules = [ // this is used as the list of all modules
@@ -182,8 +182,6 @@ const ModuleSelectionDialog = ({ modules }: { modules: string[] }) => {
     </Dialog.Content>
   </Dialog.Root>)
 };
-
-
 
 const saveLayout = (layout: Layout) => {
   setClientSideCookie('layout', JSON.stringify(layout))

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -68,9 +68,8 @@ export function ModularDashboard({ eventCode, teamNumber, ranking, rankings, tea
 
   let layout = loadLayout()
   const modules = loadEnabledModules()
-
-  console.log('we are here')
   layout = fixLayout(layout, modules)
+
   const ResponsiveGridLayout = WidthProvider(Responsive)
 
   return (
@@ -144,7 +143,7 @@ const defaultModules = [ // this is used as the list of all modules
 ]
 
 
-const ModuleSelectionDialog = ({ modules, layout }: { modules: string[], layout: any }) => {
+const ModuleSelectionDialog = ({ modules }: { modules: string[] }) => {
   const router = useRouter()
 
   return (<Dialog.Root>


### PR DESCRIPTION
This PR adds a main dashboard view with movable and resizable "modules". This allows users to setup their own layout however they prefer.

Features
- [x] Movable modules
- [x] Resizable modules
- [ ] Modules
  - [x] OPR
  - [x] Performance
  - [x] Alliance
  - [x] Rankings
  - [ ] Variants
  - [ ] literally anything idk
- [ ] Toggle for moving/resizing modules
- [x] Save layout with cookies so it isn't reset on refresh
- [x] Add and remove modules
