### PR TITLE
feat: added pop-up to change auto refresh time

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -117,7 +117,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto py-8">
       <Card className="shadow-lg">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">


### PR DESCRIPTION
when clicking on the settings icon on the team dashboard, you can change how often the data refreshes. also tweaked the padding on the main dashboard screen. 

dropdown menu from the settings icon is still mostly cooked tho, some of the options should be removed or moved somewhere else like a navbar for home/change team.